### PR TITLE
Computes correct url from aws region + minor tweaks

### DIFF
--- a/R/http.r
+++ b/R/http.r
@@ -1,14 +1,20 @@
-s3HTTP <- function(verb, url, headers, region, key, secret, parse_response = TRUE, ...) {
-    if(missing(verb))
-        verb <- "GET"
-    if(missing(headers))
-        headers <- list()
-    if(missing(region))
-        region <- "us-east-1"
-    if(missing(key))
-        key <- Sys.getenv("AWS_ACCESS_KEY_ID")
-    if(missing(secret))
-        secret <- Sys.getenv("AWS_SECRET_ACCESS_KEY")
+s3HTTP <- function(verb = "GET",
+                   url = "https://s3.amazonaws.com",
+                   bucket = "", 
+                   path = "", 
+                   headers = list(), 
+                   region = "us-east-1", 
+                   key =  Sys.getenv("AWS_ACCESS_KEY_ID"), 
+                   secret = Sys.getenv("AWS_SECRET_ACCESS_KEY"), 
+                   parse_response = TRUE, 
+                   debug = FALSE, ...) {
+    
+    ## Endpoint must match region (the default s3.amazonaws.com is us-east-1 region only)
+    if(region != "us-east-1" && url == "https://s3.amazonaws.com")
+      url = paste0("https://s3-", region, ".amazonaws.com")
+    
+    url <- paste0(url, "/", bucket, path)
+    
     current <- Sys.time()
     d_timestamp <- format(current, "%Y%m%dT%H%M%SZ", tz = "UTC")
     p <- parse_url(url)
@@ -35,9 +41,11 @@ s3HTTP <- function(verb, url, headers, region, key, secret, parse_response = TRU
     }
     if(verb == "GET") {
         r <- GET(url, H, ...)
-        if(!parse_response) {
+        if(debug) {
+          r
+        } else if(!parse_response) {
             h <- headers(r)
-            switch(h[["content-type"]], )
+         #   switch(h[["content-type"]], )
             return(content(r)) # this needs to handle MIME-types
         } else {
             content <- content(r, "text")


### PR DESCRIPTION
Looks like the s3.amazonaws.com endpoint shown in the examples is
just the us-east-1 region.  Here I set a default url and have the s3HTTP
adjust the request to use the region specified by the region argument
(if it is different that us-east-1).  Otherwise this throws an auth
error.

I've also added separate arguments for the bucket name and object path,
since it seems more typical of S3 clients to use bucket names rather
than having to give the full url with region, bucket, and path already
constructed.  __This will break existing calls that do not specify arguments by name__!

I've removed the missing() checks in favor of explicit defaults
arguments in the `s3HTTP`.  Sorry for changing house style, but I feel
this self-documents better what the defaults are (e.g. they are visible
in the documentation file automatically without consulting the source).

`parse_response = FALSE` was currently broken since the mime-type parsing
was not implemented, so I have bypassed the unfinished `switch` call for
now, instead relying on httr's automatic mime type guessing from
`content`. I have also added an additional `debug` option, perhaps
temporarily, that returns the complete httr 'response' object for debugging
purposes.


