### PR TITLE
fix url encode of action string

### DIFF
--- a/R/s3HTTP.R
+++ b/R/s3HTTP.R
@@ -58,7 +58,13 @@ s3HTTP <- function(verb = "GET",
     
     current <- Sys.time()
     d_timestamp <- format(current, "%Y%m%dT%H%M%SZ", tz = "UTC")
-    action <- if (p$path == "") "/" else paste0("/", URLencode(p$path, TRUE))
+    action <- if (p$path == "") "/" else {
+        paste0("/", paste(sapply(
+            strsplit(p$path, '/')[[1]],
+            function(i) URLencode(i, TRUE),
+            USE.NAMES = FALSE
+        ), collapse = '/'))
+    }
     canonical_headers <- c(list(host = p$hostname,
                                 `x-amz-date` = d_timestamp), headers)
     


### PR DESCRIPTION
Fixes #64, works for me when s3 path contain signs such as `=` and `&`.