### PR TITLE
Latest release of xml2 is 1.0.0 nothing newer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     utils,
     tools,
     httr,
-    xml2 (> 1.0.0),
+    xml2 (>= 1.0.0),
     base64enc,
     digest,
     curl,


### PR DESCRIPTION
1.0.0 is the current release, don't know why R on OS X is being so strict. https://github.com/hadley/xml2/releases

Asked @hadley here also https://twitter.com/dpitkin/status/812666475165126656

Disregard if I am confused!