### PR TITLE
s3source now saves S3 object to tempfile before source().

### DIFF
--- a/R/s3source.R
+++ b/R/s3source.R
@@ -39,5 +39,6 @@ s3source <- function(object, bucket, ..., opts = NULL) {
     }
     tmp <- tempfile(fileext = ".R")
     on.exit(unlink(tmp))
+    writeBin(object = r, con = tmp)
     return(source(tmp, ...))
 }


### PR DESCRIPTION
Fixing bug introduced by commit 12332edbdddff484b9f7c999fe31e2baf43d5679