### PR TITLE
added write_to_disk parameter

### DIFF
--- a/R/get_object.R
+++ b/R/get_object.R
@@ -68,7 +68,8 @@ save_object <-
 function(object, 
          bucket, 
          file, 
-         headers = list(), 
+         headers = list(),
+         write_to_disk = FALSE,
          ...) {
     if (missing(file)) {
         stop('argument "file" is missing, with no default')
@@ -77,16 +78,30 @@ function(object,
         bucket <- get_bucketname(object)
     } 
     object <- get_objectkey(object)
-    r <- s3HTTP(verb = "GET", 
-                bucket = bucket,
-                path = paste0("/", object),
-                headers = headers,
-                ...)
-    d <- dirname(file)
-    if (!dir.exists(d)) {
-        dir.create(d, recursive = TRUE)
+    if(!write_to_disk){
+        r <- s3HTTP(verb = "GET", 
+                    bucket = bucket,
+                    path = paste0("/", object),
+                    headers = headers,
+                    ...)
+        d <- dirname(file)
+        if (!dir.exists(d)) {
+            dir.create(d, recursive = TRUE)
+        }
+        writeBin(httr::content(r, as = "raw"), con = file)        
+    } else {
+        d <- dirname(file)
+        if (!dir.exists(d)) {
+            dir.create(d, recursive = TRUE)
+        }
+        r <- s3HTTP(verb = "GET", 
+            bucket = bucket,
+            path = paste0("/", object),
+            headers = headers,
+            file_writer = httr::write_disk(file),
+            ...
+        )
     }
-    writeBin(httr::content(r, as = "raw"), con = file)
     return(file)
 }
 

--- a/R/s3HTTP.R
+++ b/R/s3HTTP.R
@@ -44,6 +44,7 @@ function(verb = "GET",
          key = NULL, 
          secret = NULL, 
          session_token = NULL,
+         file_writer = NULL,
          ...) {
     
     # locate and validate credentials
@@ -120,7 +121,11 @@ function(verb = "GET",
     
     # execute request
     if (verb == "GET") {
-        r <- GET(url, H, query = query, ...)
+        # r <- GET(url, H, query = query, ...)
+        if(is.null(file_writer))
+            r <- GET(url, H, query = query, ...)
+        else 
+            r <- GET(url, H, query = query, file_writer, ...)
     } else if (verb == "HEAD") {
         r <- HEAD(url, H, query = query, ...)
         s <- http_status(r)

--- a/man/getobject.Rd
+++ b/man/getobject.Rd
@@ -2,13 +2,14 @@
 % Please edit documentation in R/get_object.R
 \name{get_object}
 \alias{get_object}
-\alias{save_object}
 \alias{head_object}
+\alias{save_object}
 \title{Get object}
 \usage{
 get_object(object, bucket, headers = list(), parse_response = FALSE, ...)
 
-save_object(object, bucket, file, headers = list(), ...)
+save_object(object, bucket, file, headers = list(), write_to_disk = FALSE,
+  ...)
 
 head_object(object, bucket, ...)
 }
@@ -21,9 +22,9 @@ head_object(object, bucket, ...)
 
 \item{parse_response}{Passed through to \code{\link{s3HTTP}}, as this function requires a non-default setting. There is probably no reason to ever change this.}
 
-\item{\dots}{Additional arguments passed to \code{\link{s3HTTP}}.}
-
 \item{file}{An R connection, or file name specifying the local file to save the object into.}
+
+\item{\dots}{Additional arguments passed to \code{\link{s3HTTP}}.}
 }
 \value{
 If \code{file = NULL}, a raw object. Otherwise, a character string containing the file name that the object is saved to.
@@ -72,3 +73,4 @@ Some users may find the raw vector response format of \code{get_object} unfamili
 \seealso{
 \code{\link{get_bucket}}, \code{\link{put_object}}, \code{\link{delete_object}}
 }
+

--- a/man/getobject.Rd
+++ b/man/getobject.Rd
@@ -24,6 +24,8 @@ head_object(object, bucket, ...)
 
 \item{file}{An R connection, or file name specifying the local file to save the object into.}
 
+\item{write_to_disk}{To be used by save_object. Boolean specifying if the downloaded data should be written straight to disk without passing through R.}
+
 \item{\dots}{Additional arguments passed to \code{\link{s3HTTP}}.}
 }
 \value{

--- a/man/s3HTTP.Rd
+++ b/man/s3HTTP.Rd
@@ -46,6 +46,8 @@ s3HTTP(verb = "GET", bucket = "", path = "", query = NULL,
 
 \item{session_token}{Optionally, a character string containing an AWS temporary Session Token. If missing, defaults to value stored in environment variable \dQuote{AWS_SESSION_TOKEN}.}
 
+\item{file_writer}{Optional parameter to be used when save_object write directly to disk. Defaults to NULL.}
+
 \item{...}{Additional arguments passed to an HTTP request function. such as \code{\link[httr]{GET}}.}
 }
 \value{

--- a/man/s3HTTP.Rd
+++ b/man/s3HTTP.Rd
@@ -9,7 +9,7 @@ s3HTTP(verb = "GET", bucket = "", path = "", query = NULL,
   dualstack = FALSE, parse_response = TRUE, check_region = TRUE,
   url_style = c("path", "virtual"), base_url = "s3.amazonaws.com",
   verbose = getOption("verbose", FALSE), region = NULL, key = NULL,
-  secret = NULL, session_token = NULL, ...)
+  secret = NULL, session_token = NULL, file_writer = NULL, ...)
 }
 \arguments{
 \item{verb}{A character string containing an HTTP verb, defaulting to \dQuote{GET}.}
@@ -57,3 +57,4 @@ This is the workhorse function for executing API requests for S3.
 \details{
 This is mostly an internal function for executing API requests. In almost all cases, users do not need to access this directly.
 }
+


### PR DESCRIPTION
I've added a parameter to the save_object method to avoid passing large objects through R memory and straight to disk. I did this to avoid running into:
``` Error in writeBin(httr::content(r, as = "raw"), con = file) :
  long vectors not supported yet: connections.c:4122
```
when using save_object to download a large file (2.9GB)

I've implemented it as an optional parameter but I think it could be made the default, would be good to get your input on this.