### PR TITLE
add .onLoad() and .onAttach() functions which call use_credentials() …

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -133,7 +133,7 @@ flatten_list <- function(x) {
     # If credentials are in environment variables, use those.
     creds <- aws.signature::locate_credentials()
     if (!all(is.null(creds$key), is.null(creds$secret))) {
-        return
+        return(invisible(NULL))
     }
     # Load default AWS credentials so calls to S3 'just work', allowing
     # the package to behave like the AWS CLI
@@ -142,9 +142,4 @@ flatten_list <- function(x) {
     } else {
         aws.signature::use_credentials()
     }
-}
-
-# Handle when package is attached (invoked with pkg::function()) not loaded
-.onAttach <- function(libname, pkgname) {
-    .onLoad(libname, pkgname)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -137,9 +137,11 @@ flatten_list <- function(x) {
     }
     # Load default AWS credentials so calls to S3 'just work', allowing
     # the package to behave like the AWS CLI
-    if (nchar(Sys.getenv("AWS_PROFILE"))) {
-        aws.signature::use_credentials(Sys.getenv("AWS_PROFILE"))
-    } else {
-        aws.signature::use_credentials()
+    if (file.exists(aws.signature::default_credentials_file())) {
+      if (nchar(Sys.getenv("AWS_PROFILE"))) {
+          aws.signature::use_credentials(Sys.getenv("AWS_PROFILE"))
+      } else {
+          aws.signature::use_credentials()
+      }
     }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -127,3 +127,24 @@ flatten_list <- function(x) {
         return(x)
     }
 }
+
+# This function gets called on package load.
+.onLoad <- function(libname, pkgname) {
+    # If credentials are in environment variables, use those.
+    creds <- aws.signature::locate_credentials()
+    if (!all(is.null(creds$key), is.null(creds$secret))) {
+        return
+    }
+    # Load default AWS credentials so calls to S3 'just work', allowing
+    # the package to behave like the AWS CLI
+    if (nchar(Sys.getenv("AWS_PROFILE"))) {
+        aws.signature::use_credentials(Sys.getenv("AWS_PROFILE"))
+    } else {
+        aws.signature::use_credentials()
+    }
+}
+
+# Handle when package is attached (invoked with pkg::function()) not loaded
+.onAttach <- function(libname, pkgname) {
+    .onLoad(libname, pkgname)
+}


### PR DESCRIPTION
…if necessary, closes #182 

Added a hook at package startup/attach time which (if creds have not been supplied via environment variables) runs `aws.signature::use_credentials()` so that users with
aws profiles (in `~/.aws`) do not have to manually type that command before they can use S3.