### PR TITLE
Replace dir.exists() with file.exists()

### DIFF
--- a/R/get_object.R
+++ b/R/get_object.R
@@ -79,7 +79,7 @@ function(object,
     
     # create dir() if missing
     d <- dirname(file)
-    if (!dir.exists(d)) {
+    if (!file.exists(d)) {
         dir.create(d, recursive = TRUE)
     }
     

--- a/R/s3sync.R
+++ b/R/s3sync.R
@@ -63,7 +63,7 @@ s3sync <- function(files = dir(recursive = TRUE), bucket, verbose = TRUE, ...) {
     if (length(missingfiles)) {
         for (i in seq_along(missingfiles)) {
             # create missing directory if needed locally
-            if (!dir.exists(dirname(missingfiles[i]))) {
+            if (!file.exists(dirname(missingfiles[i]))) {
                 if (isTRUE(verbose)) {
                     message(sprintf("Creating directory '%s'", dirname(missingfiles[i])))
                 }
@@ -143,7 +143,7 @@ s3sync <- function(files = dir(recursive = TRUE), bucket, verbose = TRUE, ...) {
             } else if (timediff[i] < 0) {
                 # object is newer than file
                 thisdir <- dirname(tosync[i])
-                if (!dir.exists(thisdir)) {
+                if (!file.exists(thisdir)) {
                     if (isTRUE(verbose)) {
                         message(sprintf("Creating directory '%s'", thisdir))
                     }


### PR DESCRIPTION
`dir.exists()` is a R 3.2.0 function. Therefore, key functions in this package such as `get_object()` won't work for R versions earlier than 3.2.0. Replacing `dir.exists()` with `file.exists()` will fix the issue. Though `file.exists()` won't be able to detect if the path is a file or folder, it is used with `dirname()` in all three changes I made. So I think it should not be a problem.

If, for some reasons that `dir.exists()` is absolutely necesary, 

> Depends: R >= 3.2.0 

should be added to the `DESCRIPTION` file.