### PR TITLE
Remove superfluous call to get_region

### DIFF
--- a/R/delete_object.R
+++ b/R/delete_object.R
@@ -18,7 +18,6 @@ delete_object <- function(object, bucket, quiet = TRUE, ...) {
     if (missing(bucket)) {
         bucket <- get_bucketname(object)
     }
-    regionname <- get_region(bucket)
     object <- get_objectkey(object)
     if (length(object) == 1) {
         r <- s3HTTP(verb = "DELETE", 


### PR DESCRIPTION
Resolves #189 

This was breaking my use case of using a custom base_url which
is how I found it in the first place.