### PR TITLE
Fix s3write_using when there are opts

### DIFF
--- a/R/s3read_using.R
+++ b/R/s3read_using.R
@@ -42,7 +42,7 @@ s3write_using <- function(x, FUN, ..., object, bucket, opts = NULL) {
     if (is.null(opts)) {
         r <- put_object(file = tmp, bucket = bucket, object = object)
     } else {
-        r <- do.call("put_object", c(list(file = rawConnectionValue(tmp), bucket = bucket, object = object), opts))
+        r <- do.call("put_object", c(list(file = tmp, bucket = bucket, object = object), opts))
     }
     return(invisible(r))
 }


### PR DESCRIPTION
The file argument `tmp` is created by `tempfile()` so `rawConnectionValue` does not work on it. This matches up with the rest of the S3 access functions, such as
 ```
r <- do.call("save_object", c(list(bucket = bucket, object = object, file = tmp), opts))
``` 
on line 63 of the same file.

Here is an example (pardon the non-standard approach to access/secret key management):

```
MYKEY <- Sys.getenv("AWS_ACCESS_KEY_ID")
MYSECRET <- Sys.getenv("AWS_SECRET_ACCESS_KEY")

bucket <- get_bucket("mybucket")  

s3write_using(x = iris, write.csv, object = "iris.csv",
  bucket = bucket, opts = list(key = MYKEY, secret = MYSECRET))

# This works
s3write_using(x = iris, write.csv, object = "iris.csv", bucket = bucket)
```
