### PR TITLE
README saveRDS instead of readRDS

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -81,7 +81,7 @@ There are eight main functions that will be useful for working with objects in S
  4. `save_object()` saves an S3 object to a specified local file
  5. `put_object()` stores a local file into an S3 bucket
  6. `s3save()` saves one or more in-memory R objects to an .Rdata file in S3 (analogously to `save()`). `s3saveRDS()` is an analogue for `saveRDS()`
- 7. `s3load()` loads one or more objects into memory from an .Rdata file stored in S3 (analogously to `load()`). `s3readRDS()` is an analogue for `saveRDS()`
+ 7. `s3load()` loads one or more objects into memory from an .Rdata file stored in S3 (analogously to `load()`). `s3readRDS()` is an analogue for `readRDS()`
  8. `s3source()` sources an R script directly from S3
 
 They behave as you would probably expect:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ There are eight main functions that will be useful for working with objects in S
  4. `save_object()` saves an S3 object to a specified local file
  5. `put_object()` stores a local file into an S3 bucket
  6. `s3save()` saves one or more in-memory R objects to an .Rdata file in S3 (analogously to `save()`). `s3saveRDS()` is an analogue for `saveRDS()`
- 7. `s3load()` loads one or more objects into memory from an .Rdata file stored in S3 (analogously to `load()`). `s3readRDS()` is an analogue for `saveRDS()`
+ 7. `s3load()` loads one or more objects into memory from an .Rdata file stored in S3 (analogously to `load()`). `s3readRDS()` is an analogue for `readRDS()`
  8. `s3source()` sources an R script directly from S3
 
 They behave as you would probably expect:


### PR DESCRIPTION
Super small README typo fix. `saveRDS()` is mentioned twice both in `s3save()` and `s3load()` instead of just `s3save()`

Please ensure the following before submitting a PR:

 - [ NA ] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.s3/issues/new) first
 - [ NA ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.s3/blob/master/DESCRIPTION)
 - [ NA ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.s3/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ NA ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ NA ] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.s3/tree/master/tests/testthat) for any new functionality or bug fix
 - [X] make sure `R CMD check` runs without error before submitting the PR

