### PR TITLE
move get_objectkey after the bucketname has been extracted

### DIFF
--- a/R/acl.R
+++ b/R/acl.R
@@ -15,12 +15,12 @@
 #' @export
 get_acl <- function(object, bucket, ...) {
     if (!missing(object)) {
-        object <- get_objectkey(object)
         if (!missing(bucket)) {
             bucket <- get_bucketname(bucket)
         } else {
             bucket <- get_bucketname(object)
         }
+        object <- get_objectkey(object)
         r <- s3HTTP(verb = "GET", 
                     path = paste0('/', object),
                     bucket = bucket,


### PR DESCRIPTION
Need to `get_bucketname` of the object, when bucket is missing, before `get_objectkey` from object or object and bucket will both be the objectkey.
