### PR TITLE
unlink tmp on exit in s3read_using

### DIFF
--- a/R/s3read_using.R
+++ b/R/s3read_using.R
@@ -57,6 +57,7 @@ s3read_using <- function(FUN, ..., object, bucket, opts = NULL) {
     object <- get_objectkey(object)
     
     tmp <- tempfile(fileext = paste0(".", tools::file_ext(object)))
+    on.exit(unlink(tmp), add = TRUE)
     if (is.null(opts)) {
         r <- save_object(bucket = bucket, object = object, file = tmp)
     } else {


### PR DESCRIPTION
s3read_using should unlink the tempfile on exit, just as s3write_using does.

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements: Issue #270 
 - [NA] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.s3/blob/master/DESCRIPTION)
 - [NA] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.s3/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [NA] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [NA] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.s3/tree/master/tests/testthat) for any new functionality or bug fix
 - [X] make sure `R CMD check` runs without error before submitting the PR: this failed with `devtools::check()` but it also fails with the same errors when going off of the current version of master.
