### PR TITLE
cast calculate_data_size return to numeric to handle large files

### DIFF
--- a/R/put_object.R
+++ b/R/put_object.R
@@ -284,5 +284,5 @@ calculate_data_size <- function(data) {
         post_size <- length((data))
     }
 
-    return(as.integer(post_size))
+    return(as.numeric(post_size))
 }


### PR DESCRIPTION
I think this tiny PR solves https://github.com/cloudyr/aws.s3/issues/264 . In short, multipart uploads using `put_object` were failing when the filesize in bytes exceeded the `as.integer` size cap. Credit entirely to @RyanKlaas for pointing out where the issue was.

As always, thanks for `aws.s3` and the whole suite of tools!

Please ensure the following before submitting a PR:

 - [X] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.s3/issues/new) first
 - [NA] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.s3/blob/master/DESCRIPTION)
 - [NA] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.s3/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [NA] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [NA] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.s3/tree/master/tests/testthat) for any new functionality or bug fix
 - [X] make sure `R CMD check` runs without error before submitting the PR

