### PR TITLE
Force S3 timestamps to be read as UTC.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"),
              person("Steven", "Akins", role = "ctb"),
              person("Bao", "Nguyen", role = "ctb"),
              person("Thierry", "Onkelinx", role = "ctb"),
-             person("Andrii", "Degtiarov", role = "ctb"))
+             person("Andrii", "Degtiarov", role = "ctb"),
+             person("Michael", "Beigelmacher", role = "ctb"))
 Description: A simple client package for the Amazon Web Services ('AWS') Simple
     Storage Service ('S3') 'REST' 'API' <https://aws.amazon.com/s3/>.
 License: GPL (>= 2)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Add `acl` and `header` arguments to `put_acl()`, ala `put_object()`. (#137)
 * Make sure content-length is an integer (#254)
+* Fix bug with `s3sync()` not uploading recently updated files (#297)` 
 
 # aws.s3 0.3.19
 

--- a/R/s3sync.R
+++ b/R/s3sync.R
@@ -133,7 +133,7 @@ s3sync <- function(files = dir(recursive = TRUE), bucket, direction = c("upload"
         ## check time modified
         modifiedfiles <- file.info(tosync)$mtime
         modifiedobjects <- unname(unlist(lapply(b[whichinboth[!matched]], `[[`, "LastModified")))
-        modifiedobjects <- strptime(modifiedobjects, format = "%FT%H:%M:%OSZ")
+        modifiedobjects <- strptime(modifiedobjects, format = "%FT%H:%M:%OSZ", tz = "UTC")
         timediff <- modifiedfiles - modifiedobjects
         
         # sync files


### PR DESCRIPTION
Please ensure the following before submitting a PR:

 - [ ] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.s3/issues/new) first
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.s3/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.s3/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ ] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.s3/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR

