### PR TITLE
Formatting content-length to prevent scientific notation. 

### DIFF
--- a/R/delete_object.R
+++ b/R/delete_object.R
@@ -38,7 +38,7 @@ delete_object <- function(object, bucket, quiet = TRUE, ...) {
                     bucket = bucket,
                     query = list(delete = ""),
                     request_body = tmpfile,
-                    headers = list(`Content-Length` = file.size(tmpfile), 
+                    headers = list(`Content-Length` = formatSize(file.size(tmpfile)), 
                                    `Content-MD5` = md), 
                     ...)
         return(TRUE)

--- a/R/put_object.R
+++ b/R/put_object.R
@@ -153,7 +153,7 @@ function(
             r <- s3HTTP(verb = "PUT", 
                         bucket = bucket,
                         path = paste0('/', object),
-                        headers = list(`Content-Length` = length(data)),
+                        headers = list(`Content-Length` = formatSize(length(data))),
                         query = list(partNumber = i, uploadId = id),
                         request_body = data,
                         verbose = verbose,
@@ -177,11 +177,11 @@ function(
     } else {
         if (!"Content-Length" %in% names(headers)) {
             headers <- c(headers, list(
-                         `Content-Length` = calculate_data_size(file)
+                         `Content-Length` = formatSize(calculate_data_size(file))
                          ))
         }
-        if (headers[["Content-Length"]] > 1e7) {
-            message(sprintf("File size is %d. Consider setting 'multipart = TRUE'.", headers[["Content-Length"]]))
+        if (as.numeric(headers[["Content-Length"]]) > 1e7) {
+            message(sprintf("File size is %s. Consider setting 'multipart = TRUE'.", headers[["Content-Length"]]))
         }
         r <- s3HTTP(verb = "PUT", 
                     bucket = bucket,
@@ -214,7 +214,7 @@ post_object <- function(file, object, bucket, headers = list(), ...) {
         object <- get_objectkey(object)
     }
     if (!"Content-Length" %in% names(headers)) {
-        headers <- c(headers, list(`Content-Length` = calculate_data_size(file)))
+        headers <- c(headers, list(`Content-Length` = formatSize(calculate_data_size(file))))
     }
     r <- s3HTTP(verb = "POST", 
                 bucket = bucket,
@@ -285,4 +285,8 @@ calculate_data_size <- function(data) {
     }
 
     return(as.numeric(post_size))
+}
+
+formatSize <- function(size) {
+  return(format(size, scientific = FALSE)) 
 }

--- a/R/tagging.R
+++ b/R/tagging.R
@@ -42,7 +42,7 @@ put_tagging <- function(bucket, tags = list(), ...){
                 bucket = bucket,
                 query = list(tagging = ""),
                 request_body = tmpfile,
-                headers = list(`Content-Length` = file.size(tmpfile), 
+                headers = list(`Content-Length` = formatSize(file.size(tmpfile)), 
                                    `Content-MD5` = md),
                 ...)
     return(TRUE)


### PR DESCRIPTION
The original fix for issue #254 didn't work; file sizes like 300,000 bytes would still lead to BadRequest errors. This fix ensures the file size is not converted to scientific notation. I searched the entire repo for 'content-length' and applied the formatting there. I created a single `formatSize` function just in case in the future we find other requirements on the format, in which case we only need to change it in one place.