### PR TITLE
Update s3HTTP.R

### DIFF
--- a/R/s3HTTP.R
+++ b/R/s3HTTP.R
@@ -236,7 +236,7 @@ parse_aws_s3_response <- function(r, Sig, verbose = getOption("verbose")){
         message("Parsing AWS API response")
     }
     ctype <- httr::headers(r)[["content-type"]]
-    if (is.null(ctype) || ctype == "application/xml"){
+    if (is.null(ctype) || grepl("application/xml", ctype)){
         content <- httr::content(r, as = "text", encoding = "UTF-8")
         if (content != "") {
             response_contents <- xml2::as_list(xml2::read_xml(content))


### PR DESCRIPTION
`ctype == "application/xml"` is way too strict. For s3-like platforms, you can get returns like `"application/xml; utf-8"` and the entire package fails to parse and flatten.

It's a small, but incredibly impactful, change. (Not sure it warrants changing the DESCRIPTION).

- [x] filed issue (found a duplicate after the fact #356 )
- [x] passed R CMD check