### PR TITLE
DRAFT: expose s3HTTP error checking without parse_response to e.g allow e.g 404's to be surfaced 

### DIFF
--- a/R/get_object.R
+++ b/R/get_object.R
@@ -7,6 +7,7 @@
 #' @param request_body For \code{select_object}, an XML request body as described in the \href{https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html}{SELECT API documentation}.
 #' @param headers List of request headers for the REST call.
 #' @param parse_response Passed through to \code{\link{s3HTTP}}, as this function requires a non-default setting. There is probably no reason to ever change this.
+#' @param do_standalone_check_for_http_errors Passed through to \code{\link{s3HTTP}}, as this function requires a non-default setting. There is probably no reason to ever change this.
 #' @param as Passed through to \code{httr::content}. 
 #' @template dots
 #' @details \code{get_object} retrieves an object into memory as a raw vector. This page describes \code{get_object} and several wrappers that provide additional useful functionality.
@@ -80,6 +81,7 @@ function(object,
          bucket, 
          headers = list(), 
          parse_response = FALSE, 
+         do_standalone_check_for_http_errors = FALSE,
 		 as = "raw",
          ...) {
     if (missing(bucket)) {
@@ -91,6 +93,7 @@ function(object,
                 path = paste0("/", object),
                 headers = headers,
                 parse_response = parse_response,
+                do_standalone_check_for_http_errors = do_standalone_check_for_http_errors,
                 ...)
     cont <- httr::content(r, as = as)
     return(cont)
@@ -136,6 +139,7 @@ function(
   request_body,
   headers = list(),
   parse_response = FALSE,
+  do_standalone_check_for_http_errors = TRUE,
   ...
 ) {
     if (missing(bucket)) {
@@ -150,6 +154,7 @@ function(
                 query = list(select = "", "select-type" = "2"),
                 request_body = request_body,
                 parse_response = parse_response,
+                do_standalone_check_for_http_errors = do_standalone_check_for_http_errors,
                 ...)
     cont <- httr::content(r, as = "raw")
     return(cont)


### PR DESCRIPTION
I'm looking to assist with S3-SELECT support.

To do this I've made a repo https://github.com/slodge/aws.s3.select which has header generating and response parsing methods.

However, these methods need code which is currently buried inside parse_response handling under s3HTTP.

This PR tries to open up that error handling... I'm open to other ways to do this.

Current state

 - [x ] code changes or improvements - linked to #282 
 - [x] trivial change - so not adding to DESCRIPTION
 - [ ] note yet added to [NEWS.md](https://github.com/cloudyr/aws.s3/blob/master/NEWS.md) - waiting to hear if this is wanted/welcome - or if alternative suggested
 - [ ] edited docs - but not yet rerun the document() - expecting changes...
 - [ ] not added any new tests yet
 - [ ] `R CMD check` does not run  - have some tests and some confusing docs to work through yet

