### PR TITLE
Bugfix to as.data.frame.s3_bucket error when S3 object only contains Owner ID and not DisplayName (close #368)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Authors@R: c(person("Thomas J.", "Leeper", role = "aut",
              person("Andrii", "Degtiarov", role = "ctb"),
              person("Dhruv", "Aggarwal", role = "ctb"),
              person("Alyssa", "Columbus", role = "ctb"),
+             person("Vitali", "Marenny", role = "ctb"),
              person("Simon", "Urbanek", role = c("cre", "ctb"),
                     email = "simon.urbanek@R-project.org")
 	     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# aws.s3 0.3.23
+
+## Bugfixes
+
+* `as.data.frame.s3_bucket` correct logic that results in function error when 
+[[Owner]][[ID]] is populated and [[Owner]][[DisplayName]] is not. 
+In the case above map [[Owner]] to Owner_ID, and Owner_DisplayName to NA (#368).
+
+
 # aws.s3 0.3.22
 
 ## API changes

--- a/R/utils.R
+++ b/R/utils.R
@@ -98,9 +98,11 @@ as.data.frame.s3_bucket <- function(x, row.names = NULL, optional = FALSE, ...) 
               ETag = z[["ETag"]],
               Size = z[["Size"]],
               Owner_ID =
-                ifelse(is.null(z[["Owner"]]), NA, z[["Owner"]][["ID"]]),
+                  ifelse(is.null(z[["Owner"]]), NA, 
+                         ifelse(length(z[["Owner"]]), z[["Owner"]], z[["Owner"]][["ID"]])),
               Owner_DisplayName =
-                ifelse(is.null(z[["Owner"]]), NA, z[["Owner"]][["DisplayName"]]),
+                  ifelse(is.null(z[["Owner"]]), NA, 
+                         ifelse(length(z[["Owner"]]), NA, z[["Owner"]][["DisplayName"]])),
               StorageClass = z[["StorageClass"]],
               Bucket = z[["Bucket"]])
         })


### PR DESCRIPTION
## Bugfixes

* `as.data.frame.s3_bucket` correct logic that results in function error when 
[[Owner]][[ID]] is populated and [[Owner]][[DisplayName]] is not. 
In the case above map [[Owner]] to Owner_ID, and Owner_DisplayName to NA (#368).

--------
Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.s3/issues/new) first
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.s3/blob/master/DESCRIPTION)
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.s3/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed


