### PR TITLE
Fix DigitalOcean get_bucket pagination

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Authors@R: c(person("Thomas J.", "Leeper", role = "aut",
              person("Andrii", "Degtiarov", role = "ctb"),
              person("Dhruv", "Aggarwal", role = "ctb"),
              person("Alyssa", "Columbus", role = "ctb"),
+             person("Pieter", "Provoost", role = "ctb"),
              person("Simon", "Urbanek", role = c("cre", "ctb"),
                     email = "simon.urbanek@R-project.org")
 	     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 ## Bugfixes
 
 * `put_object` now closes its connections properly (#354)
+* `get_bucket` now works with DigitalOcean (#393)
 
 
 # aws.s3 0.3.21


### PR DESCRIPTION
This PR fixes `get_bucket()` pagination for DigitalOcean Spaces, see https://github.com/cloudyr/aws.s3/issues/393. This solution has **not** been tested with AWS.
