### PR TITLE
save_object: wrap s3HTTP call in try to be able to remove files created for missing objects.

### DIFF
--- a/R/get_object.R
+++ b/R/get_object.R
@@ -118,13 +118,22 @@ function(object,
     }
     
     # use httr::write_disk() to write directly to disk
-    r <- s3HTTP(verb = "GET", 
-                bucket = bucket,
-                path = paste0("/", object),
-                headers = headers,
-                write_disk = httr::write_disk(path = file, overwrite = overwrite),
-                ...)
-    return(file)
+    r <- try(
+      s3HTTP(verb = "GET", 
+             bucket = bucket,
+             path = paste0("/", object),
+             headers = headers,
+             write_disk = httr::write_disk(path = file, overwrite = overwrite),
+             ...)
+    )
+    
+    if (inherits(r, "try-error")) {
+      file.remove(file)
+      if (length(dir(d)) == 0) file.remove(d)
+      stop(r, call. = FALSE)
+    }
+    
+      return(file)
 }
 
 #' @rdname get_object


### PR DESCRIPTION
Hi, 

one more suggestion for `save_object()` related to #288. 

Currently the file is created and populated with the response error, if the relevant object/key is not available on the s3 bucket.

``` r
library(aws.s3)

bucket = "1000genomes"

key = "abc.txt"
file = file.path(tempdir(), bucket, key)

# current behavior 
#   file is created and http-error is written to file 
res = try(save_object(object = key, bucket = bucket, file = file))
#> Error in parse_aws_s3_response(r, Sig, verbose = verbose) : 
#>   Not Found (HTTP 404).

res
#> [1] "Error in parse_aws_s3_response(r, Sig, verbose = verbose) : \n  Not Found (HTTP 404).\n"
#> attr(,"class")
#> [1] "try-error"
#> attr(,"condition")
#> <http_404 in parse_aws_s3_response(r, Sig, verbose = verbose): Not Found (HTTP 404).>

xml2::read_xml(file)
#> {xml_document}
#> <Error>
#> [1] <Code>NoSuchKey</Code>
#> [2] <Message>The specified key does not exist.</Message>
#> [3] <Key>abc.txt</Key>
#> [4] <RequestId>16MVA0HKJMWCNBRF</RequestId>
#> [5] <HostId>E90D/iq42bKJwh6zwdE7uk8qulfek1dHBqTeEy9y+IpgP3e6Qk6R8R5V2x/k5225Y ...
```

<sup>Created on 2021-09-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

What about wrapping the `s3HTTP` call in a try, and then remove the file (and directory) on `try-error`?
This would result in the following:

``` r
library(aws.s3)

bucket = "1000genomes"

key = "abc.txt"
file = file.path(tempdir(), bucket, key)

# new behavior 
#   file is created, result is captured, file deleted if error
res = try(save_object(object = key, bucket = bucket, file = file))
#> Error : Error in parse_aws_s3_response(r, Sig, verbose = verbose) : 
#>   Not Found (HTTP 404).

res
#> [1] "Error : Error in parse_aws_s3_response(r, Sig, verbose = verbose) : \n  Not Found (HTTP 404).\n\n"
#> attr(,"class")
#> [1] "try-error"
#> attr(,"condition")
#> <simpleError: Error in parse_aws_s3_response(r, Sig, verbose = verbose) : 
#>   Not Found (HTTP 404).
#> >

file.exists(file)
#> [1] FALSE
```

<sup>Created on 2021-09-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Happy to discuss if this helps.

Thanks, Christoph
