### PR TITLE
Add condition on multipart msg in put_object

### DIFF
--- a/R/put_object.R
+++ b/R/put_object.R
@@ -246,7 +246,7 @@ function(
         return(TRUE)
     }
 
-    if (!is.na(size) && size > partsize)
+    if (!is.na(size) && size > partsize && isFALSE(multipart))
         message("File size is ", size, ", consider setting using multipart=TRUE")
 
     ## httr doesn't support connections so we have to read it all into memory first


### PR DESCRIPTION
Relatively trivial, but current function includes message recommending multipart upload even when `multipart = TRUE`. Current message is harmless, but it caused me to think some arg values may be ignored.