### PR TITLE
Fix #407—list Backblaze S3 contents

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Authors@R: c(person("Thomas J.", "Leeper", role = "aut",
              person("Andrii", "Degtiarov", role = "ctb"),
              person("Dhruv", "Aggarwal", role = "ctb"),
              person("Alyssa", "Columbus", role = "ctb"),
+	     person("Michael", "Enion", role = "ctb"),
              person("Simon", "Urbanek", role = c("cre", "ctb"),
                     email = "simon.urbanek@R-project.org")
 	     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# aws.s3 0.3.22x
+
+* `get_bucket_df` no longer throws an error when listing bucket contents from a Backblaze S3 bucket. Fixes #407.
+
 # aws.s3 0.3.22
 
 ## API changes

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,8 +97,8 @@ as.data.frame.s3_bucket <- function(x, row.names = NULL, optional = FALSE, ...) 
                 LastModified = z[["LastModified"]],
                 ETag = z[["ETag"]],
                 Size = z[["Size"]],
-                Owner_ID = z[["Owner"]][["ID"]]),
-                Owner_DisplayName = z[["Owner"]][["DisplayName"]]),
+                Owner_ID = z[["Owner"]][["ID"]],
+                Owner_DisplayName = z[["Owner"]][["DisplayName"]],
                 StorageClass = z[["StorageClass"]],
                 Bucket = z[["Bucket"]])
          


### PR DESCRIPTION
Fixes #407. Backblaze S3 will return bucket lists without Owner:DisplayName. This causes `as.data.frame.s3_bucket` to fail when parsing the contents for `get_bucket_df.` This PR corrects that issue by ensuring that NULL values are changed to NA in the relevant cases.

Please ensure the following before submitting a PR:

 - [ x] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.s3/issues/new) first
 - [ x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.s3/blob/master/DESCRIPTION)
 - [ x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.s3/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ ] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.s3/tree/master/tests/testthat) for any new functionality or bug fix
 - [ x] make sure `R CMD check` runs without error before submitting the PR

