### PR TITLE
Use NextMarker instead of tail() to find NextMarker

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,7 @@
 ## Bugfixes
 
 * `put_object` now closes its connections properly (#354)
-
+* `get_bucket` now references NextMarker by name, ensuring increased compatibility (#413)
 
 # aws.s3 0.3.21
 

--- a/R/get_bucket.R
+++ b/R/get_bucket.R
@@ -53,10 +53,11 @@ get_bucket <- function(bucket,
                 prefix = prefix,
                 delimiter = delimiter,
                 "max-keys" = as.integer(pmin(max - as.integer(r[["MaxKeys"]]), 1000)),
-                marker = tail(r, 1)[["Contents"]][["Key"]]
+                marker = r$NextMarker
             )
             extra <- s3HTTP(verb = "GET", bucket = bucket, query = query, parse_response = parse_response, ...)
-            new_r <- c(r, tail(extra, -5))
+            new_r <- c(r, extra)
+            new_r[["NextMarker"]] <- extra$NextMarker
             new_r[["MaxKeys"]] <- as.character(as.integer(r[["MaxKeys"]]) + as.integer(extra[["MaxKeys"]]))
             new_r[["IsTruncated"]] <- extra[["IsTruncated"]]
             attr(new_r, "x-amz-id-2") <- attr(r, "x-amz-id-2")


### PR DESCRIPTION
Previously, function erroneously assumed that XML response always had `<Content>` elements listed last, and merely used `tail()` to get the Key of the last element for use as NextMarker.

This assumption relying on ordering rather than explicitly using element names fails when clients (Redhat's CEPH S3 interface, an open source product widely used in research data centers) return XML that lists metadata fields.  Moreover, the S3 response actually provides a field called NextMarker for this very purpose, which ought to be used instead of attempting to find the last key.  My pull request simply updates the code to use `r$NextMarker` to find the NextMarker instead of using `tail(r, 1)[["Contents"]][["Key"]])`

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.s3/issues/new) first
 - [x] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.s3/blob/master/DESCRIPTION) (already a contributor)
 - [x] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.s3/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.s3/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR

