### PR TITLE
Deprecate Owner DisplayName field.

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -15,7 +15,7 @@ print.s3_object <- function(x, ...){
         cat("Owner:         ", x$Owner, "\n")    
     }
     else{
-        cat("Owner:         ", x$Owner$DisplayName, "\n")   
+        cat("Owner:         ", x$Owner$ID, "\n")
     }
     cat("Storage class: ", x$StorageClass, "\n")
     invisible(x)


### PR DESCRIPTION
Deprecate usage of DisplayName and Owner ID field if unused. Closes #437.

The DisplayName field went EoL July 15, 2025.
https://docs.aws.amazon.com/AmazonS3/latest/API/API_Owner.html

New S3 payloads sometimes return atomic `Owner` rather than `Owner$ID`, so we correctly unwrap these.

Additionally, we now always return `NA_character_` for DisplayName since this field is expected to disappear from buckets moving forward.

Hopefully this helps unblock anyone hitting this issue, I don't expect this to get merged.
